### PR TITLE
Use networkid for archive dns

### DIFF
--- a/configuration/mainnet/archiver/config.json
+++ b/configuration/mainnet/archiver/config.json
@@ -15,7 +15,7 @@
   "CatchupParallelBlocks": 128,
   "MaxAPIResourcesPerAccount": 1000000,
   "MaxConnectionsPerIP": 2,
-  "IncomingConnectionsLimit": 50,
+  "IncomingConnectionsLimit": 90,
   "EnableMetricReporting": true,
   "ColdDataDir": "/algod/data/cold-storage",
   "StateproofDir": "/algod/data",

--- a/tools/utils/network_utils.go
+++ b/tools/utils/network_utils.go
@@ -39,13 +39,13 @@ func (nu NetworkUtils) NewNetwork(name string) (Network, error) {
 		return Network{
 			Name:        betaNet,
 			StatusURL:   "https://betanet-api.voi.nodly.io/v2/status",
-			ArchivalDNS: "betanet-voi.network",
+			ArchivalDNS: "voibeta.betanet-voi.network",
 		}, nil
 	case mainNet:
 		return Network{
 			Name:        mainNet,
 			StatusURL:   "https://mainnet-api.voi.nodely.dev/v2/status",
-			ArchivalDNS: "mainnet-voi.network",
+			ArchivalDNS: "voimain.mainnet-voi.network",
 		}, nil
 	default:
 		return Network{}, fmt.Errorf("unsupported network: %s", name)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Increased the limit for incoming connections from 50 to 90, enhancing the system's ability to handle higher traffic and more concurrent users.
	- Updated DNS names for the beta and main networks, reflecting new naming conventions.

These changes aim to improve performance and scalability, preparing the application for anticipated growth in usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->